### PR TITLE
pagination changes

### DIFF
--- a/routes/filter.py
+++ b/routes/filter.py
@@ -63,13 +63,18 @@ def filter_results(request):
       query = query.filter(descriptor.ilike("%{}%".format(search_string)))
 
   page = request['data']['pagination']['page'] or 1
+  if request['data']['pagination']['per_page'] == 0:
+    liquor = query.all()
+    for bottle in liquor:
+      results.append(bottle.serialized)
+    return jsonify({'liquor': results})
   per_page = request['data']['pagination']['per_page'] or 20
   liquor = query.paginate(page=int(page), per_page=int(per_page), max_per_page=50)
-  page_count = math.ceil(query.count() / int(per_page))
-  print(page_count)
+  result_count = query.count()
+  page_count = math.ceil(result_count / int(per_page))
   for bottle in liquor:
     results.append(bottle.serialized)
-  return jsonify({'liquor': results, 'page_total': page_count})
+  return jsonify({'liquor': results, 'page_total': page_count, 'results_total': result_count})
 
 # (Browse By Store) - Address
 # (Browse All Liquor) - Description

--- a/routes/liquor.py
+++ b/routes/liquor.py
@@ -12,12 +12,13 @@ def get_bottles(request):
   page = request.args.get('page') or 1
   per_page = request.args.get('per_page') or 20
   query = Liquor.query
-  page_count = math.ceil(query.count() / int(per_page))
+  result_count = query.count()
+  page_count = math.ceil(result_count / int(per_page))
   bottles = query.order_by(Liquor.id.asc()).paginate(page=int(page), per_page=int(per_page), max_per_page=50)
   bottle_list = []
   for bottle in bottles:
     bottle_list.append(format_liquor(bottle))
-  return jsonify({'liquor': bottle_list, 'page_total': page_count})
+  return jsonify({'liquor': bottle_list, 'page_total': page_count, 'results_total': result_count})
 
 # get single bottle
 def get_bottle(id):

--- a/routes/store.py
+++ b/routes/store.py
@@ -10,13 +10,15 @@ from routes.formatting import format_liquor, format_store
 def get_stores(request):
   # page = request.args.get('page') or 1
   # per_page = request.args.get('per_page') or 20
-  stores = Store.query.order_by(Store.id.asc()).all()
-  # page_count = math.ceil(query.count() / int(per_page))
+  query = Store.query
+  stores = query.order_by(Store.id.asc()).all()
+  result_count = query.count()
+  # page_count = math.ceil(result_count / int(per_page))
   # stores = query.order_by(Store.id.asc()).paginate(page=int(page), per_page=int(per_page), max_per_page=50)
   store_list = []
   for store in stores:
     store_list.append(format_store(store))
-  return jsonify({'stores': store_list
+  return jsonify({'stores': store_list, 'results_total': result_count
   # , 'page_total': page_count
   })
 


### PR DESCRIPTION
- /filter route provides method for returning all results on single page by setting 'per_page' = 0
- /filter, /stores, and /liquor routes all provide 'results_count' metadata that shows total number of results